### PR TITLE
chore(installer): add withInstall and createName for future version

### DIFF
--- a/packages/utils/create/createName.ts
+++ b/packages/utils/create/createName.ts
@@ -1,0 +1,15 @@
+/**
+ * in future version we will discard and remove createNameSpace .
+ * So , use createName instance of createNameSpace
+ *
+ *  the vue3 style see : https://v3.vuejs.org/style-guide/#priority-a-essential
+ */
+
+import { camelize } from '../format/string'
+
+export const COMPONENT_PREFFIX_NAME = 'fe'
+
+export const createName = (name: string) => {
+  name = name.charAt(0).toLocaleLowerCase() + name.slice(1)
+  return camelize(`-${COMPONENT_PREFFIX_NAME}-${name}`)
+}

--- a/packages/utils/withInstall.ts
+++ b/packages/utils/withInstall.ts
@@ -1,0 +1,13 @@
+import { App } from 'vue'
+
+export type WithInstall<T> = T & {
+  install(app: App): void
+}
+
+export const withInstall = <T>(component: T) => {
+  ;(component as Record<string, unknown>).install = (app: App) => {
+    const { name } = component as any
+    app.component(name, component)
+  }
+  return component as WithInstall<T>
+}


### PR DESCRIPTION
## Checklist

---

- [x] Fix linting errors

## Function description

- in this version , i fund `createNameSpace` is not a good practice ,because it use Array deconstruction so , developer use it is unreasonable.

- use `widthInstall` to install component in index.ts it can optimize component collection CSS
- use `createName` can get Processed component name ,like

  ```js
  import { defineComponent } from 'vue'
  const name = createName('Avatar')

  defineComponent({
    name,
  })
  ```

---
